### PR TITLE
Make inline query template compatible with Elasticsearch 6.x

### DIFF
--- a/Kernel/Config/Files/XML/LigeroSmart.xml
+++ b/Kernel/Config/Files/XML/LigeroSmart.xml
@@ -64,25 +64,33 @@
         <Value>
             <Item ValueType="Textarea">
 {
-		    "bool": {
-		        "should": [
-		            {
-		                "prefix": {
-		                    "_all": {
-		                        "value":"{{Query}}",
-		                        "boost": 10
-		                    }
-		                }
-		            },
-		            {
-		                "match": {
-		                    "_all": {
-		                        "query":"{{Query}}"
-		                    }
-		                }
-		            }
-		        ]
-		    }
+    "bool": {
+        "should": [
+            {
+                "multi_match": {
+                    "query": "{{Query}}",
+                    "fields": [
+                        "Ticket.Title",
+                        "Ticket.Article.Subject",
+                        "Ticket.Article.Body"
+                    ],
+                    "type": "phrase_prefix",
+                    "boost": 10
+                }
+            },
+            {
+                "multi_match": {
+                    "query": "{{Query}}",
+                    "fields": [
+                        "Ticket.Title",
+                        "Ticket.Article.Subject",
+                        "Ticket.Article.Body"
+                    ],
+                    "type": "best_fields"
+                }
+            }
+        ]
+    }
 }
 			</Item>
 		</Value>


### PR DESCRIPTION
_all fields was deprecated on Elastisearch 6.x, that's why it stopped to work.