### PR TITLE
slow regex fixes #149

### DIFF
--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -60,7 +60,7 @@ sub Run {
             )
         {
             my ($ImageID) = ( $Attachment->{ContentID} =~ m{^<(.*)>$}ixms );
-            if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
+            if ( grep { $_->{Content} =~ m/<img[^>]+cid:\Q$ImageID\E/ixms } @Attachments ) {
                 $AttachmentInline = 1;
             }
         }


### PR DESCRIPTION
O sintoma deste problema é que o processo do IMAP trava tentando baixar uma mensagem com um anexo em HTML e não termina de abrir o chamado enviado por email