### PR TITLE
feat: create config Ticket::UntilDateAsDate to define until time visu…

### DIFF
--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_config version="2.0" init="Application">
+	<Setting Name="Ticket::UntilDateAsDate" Required="1" Valid="1">
+        <Description Translatable="1">Define if until time must be showed as date.</Description>
+        <Navigation>Core::Ticket</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::Hook" Required="1" Valid="1">
         <Description Translatable="1">The identifier for a ticket, e.g. Ticket#, Call#, MyTicket#. The default is Ticket#.</Description>
         <Navigation>Core::Ticket</Navigation>

--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -1598,10 +1598,17 @@ sub Run {
                 }
                 elsif ( $TicketColumn eq 'PendingTime' ) {
                     $BlockType = 'Escalation';
-                    $DataValue = $LayoutObject->CustomerAge(
+					my $UntilDateAsDate = $ConfigObject->Get("Ticket::UntilDateAsDate");
+					my $TimeObject = $LayoutObject->CustomerAge(
                         Age   => $Article{'UntilTime'},
                         Space => ' '
                     );
+					if($UntilDateAsDate) {
+						$TimeObject = $Kernel::OM->Get('Kernel::System::Time');
+						$DataValue = $TimeObject->SystemTime2TimeStamp(
+							SystemTime => ( $Article{UntilTime} + $TimeObject->SystemTime() ),
+						);
+					}
                     if ( defined $Article{UntilTime} && $Article{UntilTime} < -1 ) {
                         $CSSClass = 'Warning';
                     }


### PR DESCRIPTION
solution to tickert https://servicedesk.complemento.net.br/otrs/index.pl?Action=AgentTicketZoom;TicketID=74673. Was created a new configuration Ticket::UntilDateAsDate to define the UntilTime visualization as a complete date.