### PR TITLE
Ajuste tela AgentTicket aparecer valor em fila

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -2128,7 +2128,9 @@ sub _Mask {
 
         # set move queues
         $Param{QueuesStrg} = $LayoutObject->AgentQueueListOption(
+            Action   => $Self->{Action},
             Data     => { %MoveQueues, '' => '-' },
+            #Data     => { %MoveQueues},
             Multiple => 0,
             Size     => 0,
             Class    => 'NewQueueID Modernize '

--- a/Kernel/Output/HTML/Layout/Ticket.pm
+++ b/Kernel/Output/HTML/Layout/Ticket.pm
@@ -599,6 +599,7 @@ sub AgentQueueListOption {
                 $SelectedID eq $_
                 || $Selected eq $Param{Data}->{$_}
                 || $Param{SelectedIDRefArrayOK}->{$_}
+                || $Param{Action} =~ m{ ^AgentTicket.*$ }xmsi
                 )
             {
                 $Param{MoveQueuesStrg}


### PR DESCRIPTION
Favor implementar para atender a demanda do chamado 5177869 referente ao campo DestQueue que quando o usuário tem permissão somente na fila ao qual o chamado já está alocado o campo fica desabilitado, com esse ajuste o campo apresenta a fila atual. Somente nas telas AgentTicket.*, na tela principal é respeitado conforme modelo nativo.