### PR TITLE
Função para não apresentar timezone

### DIFF
--- a/Kernel/Config/Files/XML/DoNotShowUserTimeZone.xml
+++ b/Kernel/Config/Files/XML/DoNotShowUserTimeZone.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<otrs_config version="2.0" init="Application">
+    <Setting Name="DoNotShowUserTimeZone" Required="1" Valid="1">
+        <Description Translatable="1">If enabled, users who have selected a time zone will not be presented in date and time values.</Description>
+        <Navigation>Core::Time</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">1</Item>
+        </Value>
+    </Setting>
+</otrs_config>

--- a/Kernel/Language.pm
+++ b/Kernel/Language.pm
@@ -357,8 +357,12 @@ sub FormatTimeString {
             $Config ne 'DateFormatShort'
             && $Self->{TimeZone}
             && $Self->{TimeZone} ne Kernel::System::DateTime->OTRSTimeZoneGet()
+            && $Kernel::OM->Get('Kernel::Config')->Get('DoNotShowUserTimeZone')
             )
         {
+            return $ReturnString;
+        }
+        else {
             return $ReturnString . " ($Self->{TimeZone})";
         }
 


### PR DESCRIPTION
Função para atender a demanda de ter opção de escolher se deseja que em relatório e campos do tipo data/hora apareça o fuso horário.