### PR TITLE
Fix image inline editing of ticket articles

### DIFF
--- a/Kernel/Modules/AgentTicketArticleEdit.pm
+++ b/Kernel/Modules/AgentTicketArticleEdit.pm
@@ -281,8 +281,89 @@ sub Run {
                 UserID    => 1,
             );
             if ($Atts{$At}->{Filename} eq 'file-2'){
+                my $AttachmentsBox = {$ArticleBackendObject->ArticleAttachmentIndex(
+                    ArticleID => $Self->{ArticleID},
+                )};
                 $Body = $Attachment{Content};
                 ($Body) = $Body =~ /<body.*?>(.*?)<\/body>/s;
+
+                # build base url for inline images
+                    # generate base url
+                my $URL = 'Action=AgentTicketAttachment;Subaction=HTMLView'
+                    . ";TicketID=".$Self->{TicketID}.";ArticleID=".$Self->{ArticleID}.";FileID=";
+                my $SessionID = '';
+                if ( $Self->{SessionID} && !$Self->{SessionIDCookie} ) {
+                    $SessionID = ';' . $Self->{SessionName} . '=' . $Self->{SessionID};
+                }
+
+                # replace inline images in content with runtime url to images
+                my $AttachmentLink = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->{Baselink} . $URL;
+                $Body =~ s{
+                    (=|"|')cid:(.*?)("|'|>|\/>|\s)
+                }
+                {
+                    my $Start= $1;
+                    my $ContentID = $2;
+                    my $End = $3;
+
+                    # improve html quality
+                    if ( $Start ne '"' && $Start ne '\'' ) {
+                        $Start .= '"';
+                    }
+                    if ( $End ne '"' && $End ne '\'' ) {
+                        $End = '"' . $End;
+                    }
+
+                    # find matching attachment and replace it with runtime url to image
+                    ATTACHMENT_ID:
+                    for my $AttachmentID (  sort keys %{ $AttachmentsBox }) {
+                        next ATTACHMENT_ID if lc $AttachmentsBox->{$AttachmentID}->{ContentID} ne lc "<$ContentID>";
+                        $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
+                        last ATTACHMENT_ID;
+                    }
+
+                    # return new runtime url
+                    $Start . $ContentID . $End;
+                }egxi;
+
+                # bug #5053
+                # inline images using Content-Location as identifier instead of Content-ID even RFC2557
+                # http://www.ietf.org/rfc/rfc2557.txt
+
+                # find matching attachment and replace it with runtlime url to image
+                ATTACHMENT:
+                for my $AttachmentID ( sort keys %{ $AttachmentsBox } ) {
+                    next ATTACHMENT if !$AttachmentsBox->{$AttachmentID}->{ContentID};
+
+                    # content id cleanup
+                    $AttachmentsBox->{$AttachmentID}->{ContentID} =~ s/^<//;
+                    $AttachmentsBox->{$AttachmentID}->{ContentID} =~ s/>$//;
+
+                    next ATTACHMENT if !$AttachmentsBox->{$AttachmentID}->{ContentID};
+
+                    $Body =~ s{
+                    (=|"|')(\Q$AttachmentsBox->{$AttachmentID}->{ContentID}\E)("|'|>|\/>|\s)
+                }
+                {
+                    my $Start= $1;
+                    my $ContentID = $2;
+                    my $End = $3;
+
+                    # improve html quality
+                    if ( $Start ne '"' && $Start ne '\'' ) {
+                        $Start .= '"';
+                    }
+                    if ( $End ne '"' && $End ne '\'' ) {
+                        $End = '"' . $End;
+                    }
+
+                    # return new runtime url
+                    $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
+                    $Start . $ContentID . $End;
+                }egxi;
+                }
+
+                $Article{Body} = $Body;
 #                last ATTACHMENTS;
             } else {
                 $UploadCacheObject->FormIDAddFile(
@@ -292,13 +373,13 @@ sub Run {
             }
         }
         
-	 $Article{Body} = $LayoutObject->Ascii2Html(
-            NewLine        => $ConfigObject->Get('DefaultViewNewLine'),
-            Text           => $Article{Body},
-            VMax           => $ConfigObject->Get('DefaultViewLines') || 5000,
-            HTMLResultMode => 1,
-            LinkFeature    => 1,
-        );
+	#  $Article{Body} = $LayoutObject->Ascii2Html(
+    #         NewLine        => $ConfigObject->Get('DefaultViewNewLine'),
+    #         Text           => $Article{Body},
+    #         VMax           => $ConfigObject->Get('DefaultViewLines') || 5000,
+    #         HTMLResultMode => 1,
+    #         LinkFeature    => 1,
+    #     );
 
  	  $GetParam{Body}= $Article{Body};
    


### PR DESCRIPTION
Inline images were not being displayed in the article editor.

This commit fixes the issue by adding the missing image data to the article editor and replacing the CID with the image URL.